### PR TITLE
feat: add API rate limits and cleanup terraform

### DIFF
--- a/terraform/api-gateway.tf
+++ b/terraform/api-gateway.tf
@@ -13,50 +13,6 @@ resource "aws_apigatewayv2_stage" "default" {
 }
 
 # -------------------------------
-# ACL Rule to Rate Limit APIs
-# TODO - my cloud front distro is old, using classic and needs to be upgraded before this will work!
-# -------------------------------
-resource "aws_wafv2_web_acl" "api_rate_limit_acl" {
-  count       = 0 # Disbale until CF is upgraded from classic
-  name        = "api-rate-limit-acl"
-  description = "Rate limit API access to 20 requests per hour"
-  scope       = "CLOUDFRONT" # Use "REGIONAL" for ALB or API Gateway
-
-  default_action {
-    allow {}
-  }
-
-  rule {
-    name     = "rate-limit-signin-users"
-    priority = 1
-
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = 20
-        aggregate_key_type = "IP"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "apiRateLimit"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "apiWebACL"
-    sampled_requests_enabled   = true
-  }
-}
-
-
-# -------------------------------
 # Permissions
 # -------------------------------
 resource "aws_lambda_permission" "write_bulk" {

--- a/terraform/certs.tf
+++ b/terraform/certs.tf
@@ -1,31 +1,8 @@
-
-# Request an SSL certificate for your domain. This must be done in us-east-3.
-# -----------------------------------------------------------
-resource "aws_acm_certificate" "cert" {
-  provider          = aws.us-east-1
-  domain_name       = "micko-training2025.info"
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# We create an Origin Access Identity (OAI) for CloudFront.
-# This OAI acts as a "virtual user" to securely access your public bucket.
-resource "aws_cloudfront_origin_access_identity" "oai" {
-  comment = "OAI for micko-training2025.info"
-}
-
-# The bucket policy grants the OAI permission to read objects from the bucket
-# moved to s3_site_hosting.tf
-
-
-# Request an SSL certificate for your domain. This must be done in us-east-3.
+# Request an SSL certificate for your domain. This must be done in us-east-1
 # -----------------------------------------------------------
 resource "aws_acm_certificate" "domain2" {
   provider          = aws.us-east-1
-  domain_name       = "sign-in-out.com"
+  domain_name       = var.bucket_name
   validation_method = "DNS"
 
   lifecycle {

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -14,36 +14,36 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
 # I had to import these resources before log retention could be changed from 0 (forever) to 7 days
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["WriteBulkLogsFunction"]
-  #id = "/aws/lambda/WriteBulkLogsFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["WriteBulkLogsFunction"]
+#id = "/aws/lambda/WriteBulkLogsFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["EditNameFunction"]
-  #id = "/aws/lambda/EditNameFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["EditNameFunction"]
+#id = "/aws/lambda/EditNameFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["WriteNameFunction"]
-  #id = "/aws/lambda/WriteNameFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["WriteNameFunction"]
+#id = "/aws/lambda/WriteNameFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["WriteLogFunction"]
-  #id = "/aws/lambda/WriteLogFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["WriteLogFunction"]
+#id = "/aws/lambda/WriteLogFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["FetchLogsFunction"]
-  #id = "/aws/lambda/FetchLogsFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["FetchLogsFunction"]
+#id = "/aws/lambda/FetchLogsFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["FetchNamesFunction"]
-  #id = "/aws/lambda/FetchNamesFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["FetchNamesFunction"]
+#id = "/aws/lambda/FetchNamesFunction"
 #}
 
 #import {
-  #to = aws_cloudwatch_log_group.lambda_logs["FetchDatesFunction"]
-  #id = "/aws/lambda/FetchDatesFunction"
+#to = aws_cloudwatch_log_group.lambda_logs["FetchDatesFunction"]
+#id = "/aws/lambda/FetchDatesFunction"
 #}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,10 +1,10 @@
-resource "aws_iam_user" "mickos_github" {
-  name = "mickos-github"
+resource "aws_iam_user" "github_user" {
+  name = var.iam_user_github
 }
 
-resource "aws_iam_policy" "mickos_github_s3_write_policy" {
-  name        = "mickos-github-s3-write-policy"
-  description = "Policy to allow write and delete access to the S3 buckets for sign-in-out.com"
+resource "aws_iam_policy" "github_s3_write" {
+  name        = "github-s3-write-policy"
+  description = "Policy to allow write and delete access to the website S3 bucket"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -18,10 +18,8 @@ resource "aws_iam_policy" "mickos_github_s3_write_policy" {
           "s3:DeleteObject"
         ]
         Resource = [
-          "arn:aws:s3:::micko-training2025.info",
-          "arn:aws:s3:::micko-training2025.info/*",
-          "arn:aws:s3:::sign-in-out.com",
-          "arn:aws:s3:::sign-in-out.com/*"
+          "arn:aws:s3:::${var.bucket_name}",
+          "arn:aws:s3:::${var.bucket_name}/*"
         ]
       },
       {
@@ -30,13 +28,13 @@ resource "aws_iam_policy" "mickos_github_s3_write_policy" {
         Action = [
           "cloudfront:CreateInvalidation"
         ]
-        Resource = "arn:aws:cloudfront::722937635825:distribution/E2DY5SRXBRDW31"
+        Resource = "arn:aws:cloudfront::${var.aws_account_id}:distribution/${var.cloudfront_dist_id}"
       }
     ]
   })
 }
 
-resource "aws_iam_user_policy_attachment" "mickos_github_policy_attachment" {
-  user       = aws_iam_user.mickos_github.name
-  policy_arn = aws_iam_policy.mickos_github_s3_write_policy.arn
+resource "aws_iam_user_policy_attachment" "github" {
+  user       = aws_iam_user.github_user.name
+  policy_arn = aws_iam_policy.github_s3_write.arn
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,7 +19,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.12.0"
 }
 
 # Configure the AWS Provider

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,14 +1,4 @@
 # Output the DNS validation records. 
-output "acm_validation_record" {
-  value = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
-      name  = dvo.resource_record_name
-      type  = dvo.resource_record_type
-      value = dvo.resource_record_value
-    }
-  }
-}
-# Output the DNS validation records for 2nd cert
 output "acm_validation_record2" {
   value = {
     for dvo in aws_acm_certificate.domain2.domain_validation_options : dvo.domain_name => {

--- a/terraform/s3_site_hosting.tf
+++ b/terraform/s3_site_hosting.tf
@@ -1,6 +1,6 @@
 # SIO = SIGN-IN-OUT :) 
 resource "aws_s3_bucket" "sio" {
-  bucket = "sign-in-out.com" #must exactly match domain name
+  bucket = var.bucket_name #must exactly match domain name
 
   tags = {
     Name        = "Sign-In-Out Public Bucket"
@@ -57,35 +57,9 @@ data "aws_iam_policy_document" "sio" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::722937635825:user/micko-cli"]
+      identifiers = ["arn:aws:iam::${var.aws_account_id}:user/${var.iam_user_cli}"]
     }
   }
-
-  #OAI permissions for CloudFront to access the bucket
-  # possibly not needed now, following update to OAC... but leaving in place for now
-  #  statement {
-  #    sid       = "AllowCloudFrontGet"
-  #    effect    = "Allow"
-  #    actions   = ["s3:GetObject"]
-  #    resources = ["${aws_s3_bucket.sio.arn}/*"]
-
-  #    principals {
-  #      type        = "AWS"
-  #      identifiers = [aws_cloudfront_origin_access_identity.oai.iam_arn]
-  #    }
-  #  }
-
-  #  statement {
-  #    sid       = "AllowCloudFrontList"
-  #    effect    = "Allow"
-  #    actions   = ["s3:ListBucket"]
-  #    resources = [aws_s3_bucket.sio.arn]
-
-  #    principals {
-  #      type        = "AWS"
-  #      identifiers = [aws_cloudfront_origin_access_identity.oai.iam_arn]
-  #    }
-  #  }
 
   # Newer OAC permissions for CloudFront to access the bucket
   # generated via AWS console when cloud front was correctly updated to point to s3 website (instead of s3 api).
@@ -103,8 +77,7 @@ data "aws_iam_policy_document" "sio" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      #values   = ["arn:aws:cloudfront::722937635825:distribution/E25MMIJS9KLCP2"] # old CDN for micko-training2025
-      values   = ["arn:aws:cloudfront::722937635825:distribution/E2DY5SRXBRDW31"]
+      values   = ["arn:aws:cloudfront::${var.aws_account_id}:distribution/${var.cloudfront_dist_id}"]
     }
   }
 }

--- a/terraform/tfvars/prod.tfvars
+++ b/terraform/tfvars/prod.tfvars
@@ -1,0 +1,5 @@
+aws_account_id     = "722937635825"
+bucket_name        = "sign-in-out.com"
+cloudfront_dist_id = "E2DY5SRXBRDW31"
+iam_user_cli       = "micko-cli"
+iam_user_github    = "mickos-github"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "aws_account_id" {
+  description = "AWS account ID used for resource ARNs"
+  type        = string
+  validation {
+    condition     = can(regex("^\\d{12}$", var.aws_account_id))
+    error_message = "AWS account ID must be a 12-digit number."
+  }
+}
+
+variable "cloudfront_dist_id" {
+  description = "CloudFront distribution ID"
+  type        = string
+  validation {
+    condition     = length(var.cloudfront_dist_id) > 0
+    error_message = "CloudFront distribution ID must not be empty."
+  }
+}
+
+variable "iam_user_cli" {
+  description = "IAM user name for CLI access"
+  type        = string
+  validation {
+    condition     = length(var.iam_user_cli) > 0
+    error_message = "IAM user name must not be empty."
+  }
+}
+
+variable "iam_user_github" {
+  description = "GitHub username"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{1,39}$", var.iam_user_github))
+    error_message = "GitHub username must be 1–39 characters and contain only letters, numbers, or hyphens."
+  }
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-z0-9.-]{3,63}$", var.bucket_name))
+    error_message = "Bucket name must be 3–63 characters, lowercase, and valid for S3."
+  }
+}


### PR DESCRIPTION
- added low rate limits for cloudfront / API calls
- removed lingering tf code for old/test bucket and related resources (cert, etc)
- added variables.tf and prod.tfvars to get rid of most (not all) hard coded values specific to my site